### PR TITLE
STICKI-8 / organism 단위 컴포넌트 및 스토리북 구현

### DIFF
--- a/components/organisms/SignForm/SignForm.stories.tsx
+++ b/components/organisms/SignForm/SignForm.stories.tsx
@@ -1,0 +1,24 @@
+import { ComponentStory, ComponentMeta } from "@storybook/react"
+import { SignForm } from "./SignForm"
+
+export default {
+  title: "Components/Organism/SignForm",
+  component: SignForm,
+  argTypes: {
+    formType: {
+      defaultValue: "signIn",
+      control: {
+        type: "radio",
+        options: ["signIn", "signUp"],
+      },
+    },
+    isAlertVisible: {
+      defaultValue: false,
+      control: "boolean",
+    },
+  },
+} as ComponentMeta<typeof SignForm>
+
+export const Default: ComponentStory<typeof SignForm> = (args) => {
+  return <SignForm {...args} />
+}

--- a/components/organisms/SignForm/SignForm.styles.ts
+++ b/components/organisms/SignForm/SignForm.styles.ts
@@ -1,0 +1,9 @@
+import styled from "@emotion/styled"
+
+export const Form = styled.form`
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  width: 100%;
+  height: inherit;
+`

--- a/components/organisms/SignForm/SignForm.tsx
+++ b/components/organisms/SignForm/SignForm.tsx
@@ -1,0 +1,62 @@
+import { SignInput } from "components/molecules/SignInput"
+import * as S from "./SignForm.styles"
+import { ISignFormProps } from "types"
+
+function SignInForm({ isAlertVisible }: { isAlertVisible: boolean }) {
+  return (
+    <>
+      <SignInput
+        labelContent="E-MAIL"
+        alertContent="이메일을 입력 해 주세요"
+        isAlertVisible={isAlertVisible}
+      />
+      <SignInput
+        labelContent="PASSWORD"
+        alertContent="비밀번호를 입력 해 주세요"
+        isAlertVisible={isAlertVisible}
+      />
+    </>
+  )
+}
+
+function SignUpForm({ isAlertVisible }: { isAlertVisible: boolean }) {
+  return (
+    <>
+      <SignInput
+        labelContent="USERNAME"
+        alertContent="이름을 입력 해 주세요"
+        isAlertVisible={isAlertVisible}
+      />
+      <SignInput
+        labelContent="E-MAIL"
+        alertContent="이메일을 입력 해 주세요"
+        isAlertVisible={isAlertVisible}
+      />
+      <SignInput
+        labelContent="PASSWORD"
+        alertContent="비밀번호를 입력 해 주세요"
+        isAlertVisible={isAlertVisible}
+      />
+      <SignInput
+        labelContent="PASSWORD CONFIRM"
+        alertContent="비밀번호를 일치하게 입력 해 주세요"
+        isAlertVisible={isAlertVisible}
+      />
+    </>
+  )
+}
+export function SignForm({ formType }: ISignFormProps) {
+  return (
+    <S.Form>
+      {formType === "signIn" ? (
+        <SignInForm isAlertVisible={true} />
+      ) : (
+        <SignUpForm isAlertVisible={true} />
+      )}
+    </S.Form>
+  )
+}
+
+SignForm.defaultValue = {
+  formType: "signIn",
+}

--- a/components/organisms/SignForm/index.ts
+++ b/components/organisms/SignForm/index.ts
@@ -1,0 +1,1 @@
+export { SignForm } from "./SignForm"

--- a/types/index.ts
+++ b/types/index.ts
@@ -1,3 +1,5 @@
 export type { IBaseCardContainerProps, ILogoProps, IIconProps } from "types/atom"
 
 export type { ISignInputProps } from "types/molecule"
+
+export type { ISignFormProps } from "types/organism"

--- a/types/organism.d.ts
+++ b/types/organism.d.ts
@@ -1,0 +1,3 @@
+export interface ISignFormProps {
+  formType: "signUp" | "signIn"
+}


### PR DESCRIPTION
### 📌 설명
<!-- - 결과물(이미지 또는 움짤 참조할 것)
- 문제가 무엇인지에 대하여 분명하고 간결한 Description (이 PR을 통해 해결하는 문제)
- 문제를 해결하기 위해 도입한 개념, 방안 -->
검색 기능 중간 이름을 검색했을 때 결과가 안나오는 부분 수정

## 🎨 구현 내용
<!-- - 디렉토리, 파일 구조에 대한 설명
- 구현한 기능의 논리에 대한 설명
- 변경점에 대한 설명 -->

### organism 단위 컴포넌트 및 스토리북 생성

#### SignForm

용도 : Sign 페이지에서 사용할 Form 컴포넌트

<img width="400" alt="image" src="https://user-images.githubusercontent.com/97934878/194890765-6838eb6a-856a-4e5c-8449-03cd636ebbdf.png">


### ✅ 해결하지 못한 이슈 및 궁금한 것
<!-- - 변경사항이 큰 경우 집중해야 할 부분
- 불안해서 봐주었으면 하는 부분 등 -->

- SignForm의 isAlertVisible props를 어떻게 할지 정하지 못하였다. 이걸 각기 보여주고 안보여주기에는 너무나도 input이 많고, 한꺼번에 보여주고 마는 것은 절대 해서는 안될..... 고민이 된다 ㅜ

### 🚀 연관된 지라 이슈
Jira, STICKI-8