### PR TITLE
STICKI-11 / 대시보드_atom 단위 컴포넌트 및 스토리북 구현

### DIFF
--- a/components/atoms/CurrentNumber/CurrentNumber.stories.tsx
+++ b/components/atoms/CurrentNumber/CurrentNumber.stories.tsx
@@ -1,0 +1,26 @@
+import { ComponentStory, ComponentMeta } from "@storybook/react"
+import { CurrentNumber } from "./CurrentNumber"
+
+export default {
+  title: "Components/Atoms/CurrentNumber",
+  component: CurrentNumber,
+  argTypes: {
+    title: {
+      defaultValue: "test title",
+      control: "text",
+    },
+    count: {
+      defaultValue: 1,
+      control: {
+        type: "range",
+        min: 0,
+        max: 10,
+        step: 1,
+      },
+    },
+  },
+} as ComponentMeta<typeof CurrentNumber>
+
+export const Default: ComponentStory<typeof CurrentNumber> = (args) => {
+  return <CurrentNumber {...args} />
+}

--- a/components/atoms/CurrentNumber/CurrentNumber.styles.ts
+++ b/components/atoms/CurrentNumber/CurrentNumber.styles.ts
@@ -1,0 +1,32 @@
+import styled from "@emotion/styled"
+import { ICurrentNumberProps } from "types"
+
+export const Container = styled.div<ICurrentNumberProps>`
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+
+  width: ${({ width }) => (width ? `${width}rem` : "4.5rem")};
+  height: ${({ width }) => (width ? `${width}rem` : "4.5rem")};
+
+  border: 1px solid;
+`
+
+export const Title = styled.div`
+  height: 2rem;
+
+  color: white;
+
+  font-size: 0.75rem;
+  font-weight: 300;
+
+  word-break: keep-all;
+  overflow: hidden;
+`
+
+export const Count = styled.div`
+  color: #8294ff;
+
+  font-size: 2rem;
+  font-weight: 700;
+`

--- a/components/atoms/CurrentNumber/CurrentNumber.styles.ts
+++ b/components/atoms/CurrentNumber/CurrentNumber.styles.ts
@@ -8,8 +8,6 @@ export const Container = styled.div<ICurrentNumberProps>`
 
   width: ${({ width }) => (width ? `${width}rem` : "4.5rem")};
   height: ${({ width }) => (width ? `${width}rem` : "4.5rem")};
-
-  border: 1px solid;
 `
 
 export const Title = styled.div`

--- a/components/atoms/CurrentNumber/CurrentNumber.tsx
+++ b/components/atoms/CurrentNumber/CurrentNumber.tsx
@@ -1,0 +1,11 @@
+import { ICurrentNumberProps } from "types"
+import * as S from "./CurrentNumber.styles"
+
+export function CurrentNumber({ width, title, count, ...props }: ICurrentNumberProps) {
+  return (
+    <S.Container width={width} title={title} count={count}>
+      {title ? <S.Title>{title}</S.Title> : null}
+      <S.Count>{count}</S.Count>
+    </S.Container>
+  )
+}

--- a/components/atoms/CurrentNumber/index.ts
+++ b/components/atoms/CurrentNumber/index.ts
@@ -1,0 +1,1 @@
+export { CurrentNumber } from "./CurrentNumber"

--- a/components/atoms/DashBoardButton/DashBoardButton.stories.tsx
+++ b/components/atoms/DashBoardButton/DashBoardButton.stories.tsx
@@ -1,10 +1,51 @@
 import { ComponentStory, ComponentMeta } from "@storybook/react"
 import { DashBoardButton } from "./DashBoardButton"
 
+const testImageLink =
+  "https://cutewallpaper.org/24/studio-ghibli-png/download-hd-any-transparent-studio-ghibli-photos-and-or-gifs-jiji-kiki-la-petite-sorci%C3%A8re-transparent-png-image-nicepngcom.png"
+
 export default {
   title: "Components/Atoms/DashBoardButton",
   component: DashBoardButton,
-  argTypes: {},
+  argTypes: {
+    title: {
+      defaultValue: "test title",
+      control: "text",
+    },
+    desc: {
+      defaultValue: "test desc",
+      control: "text",
+    },
+    width: {
+      defaultValue: 5,
+      control: {
+        type: "range",
+        min: 1,
+        max: 10,
+        step: 1,
+      },
+    },
+    height: {
+      defaultValue: 10,
+      control: {
+        type: "range",
+        min: 5,
+        max: 20,
+        step: 2.5,
+      },
+    },
+    backgroundColor: {
+      defaultValue: "#B5C0FF",
+      control: "color",
+    },
+    image: {
+      defaultValue: testImageLink,
+      control: {
+        type: "radio",
+        options: [testImageLink, undefined],
+      },
+    },
+  },
 } as ComponentMeta<typeof DashBoardButton>
 
 export const Default: ComponentStory<typeof DashBoardButton> = (args) => {

--- a/components/atoms/DashBoardButton/DashBoardButton.stories.tsx
+++ b/components/atoms/DashBoardButton/DashBoardButton.stories.tsx
@@ -1,0 +1,12 @@
+import { ComponentStory, ComponentMeta } from "@storybook/react"
+import { DashBoardButton } from "./DashBoardButton"
+
+export default {
+  title: "Components/Atoms/DashBoardButton",
+  component: DashBoardButton,
+  argTypes: {},
+} as ComponentMeta<typeof DashBoardButton>
+
+export const Default: ComponentStory<typeof DashBoardButton> = (args) => {
+  return <DashBoardButton {...args} />
+}

--- a/components/atoms/DashBoardButton/DashBoardButton.styles.ts
+++ b/components/atoms/DashBoardButton/DashBoardButton.styles.ts
@@ -1,0 +1,3 @@
+import styled from "@emotion/styled"
+
+export const Container = styled.div``

--- a/components/atoms/DashBoardButton/DashBoardButton.styles.ts
+++ b/components/atoms/DashBoardButton/DashBoardButton.styles.ts
@@ -1,3 +1,53 @@
 import styled from "@emotion/styled"
 
-export const Container = styled.div``
+interface IContainerProps {
+  width?: number
+  height: number
+  backgroundColor: string
+}
+
+export const Container = styled.div<IContainerProps>`
+  display: flex;
+  flex-direction: column;
+  position: relative;
+
+  width: ${({ width }) => (width ? `${width}rem` : "100%")};
+  height: ${({ height }) => `${height}rem`};
+  padding: 1rem;
+
+  border-radius: 1rem;
+
+  background: ${({ backgroundColor }) => backgroundColor};
+  box-shadow: 0 0.5rem 1rem rgba(79, 52, 155, 0.2);
+
+  overflow: hidden;
+`
+
+export const Title = styled.div`
+  width: 100%;
+
+  color: white;
+
+  font-size: 1.25rem;
+  font-weight: 700;
+
+  word-break: keep-all;
+`
+
+export const Desc = styled.div`
+  width: 100%;
+
+  color: white;
+  font-size: 0.6rem;
+
+  word-break: keep-all;
+`
+export const ImageContainer = styled.div`
+  position: absolute;
+  bottom: 1rem;
+  right: 1rem;
+
+  width: 50%;
+  max-height: 50%;
+  height: 50%;
+`

--- a/components/atoms/DashBoardButton/DashBoardButton.tsx
+++ b/components/atoms/DashBoardButton/DashBoardButton.tsx
@@ -1,4 +1,5 @@
 import { IDashBoardButtonProps } from "types"
+import Image from "next/image"
 import * as S from "./DashBoardButton.styles"
 
 export function DashBoardButton({
@@ -7,7 +8,18 @@ export function DashBoardButton({
   width,
   height,
   image,
+  backgroundColor,
   ...props
 }: IDashBoardButtonProps) {
-  return <S.Container>DashBoardButton</S.Container>
+  return (
+    <S.Container width={width} height={height} backgroundColor={backgroundColor}>
+      <S.Title>{title}</S.Title>
+      {desc ? <S.Desc>{desc}</S.Desc> : null}
+      {image ? (
+        <S.ImageContainer>
+          <Image src={image} layout="fill" alt={`${title} image`} />
+        </S.ImageContainer>
+      ) : null}
+    </S.Container>
+  )
 }

--- a/components/atoms/DashBoardButton/DashBoardButton.tsx
+++ b/components/atoms/DashBoardButton/DashBoardButton.tsx
@@ -1,0 +1,13 @@
+import { IDashBoardButtonProps } from "types"
+import * as S from "./DashBoardButton.styles"
+
+export function DashBoardButton({
+  title,
+  desc,
+  width,
+  height,
+  image,
+  ...props
+}: IDashBoardButtonProps) {
+  return <S.Container>DashBoardButton</S.Container>
+}

--- a/components/atoms/DashBoardButton/index.ts
+++ b/components/atoms/DashBoardButton/index.ts
@@ -1,0 +1,1 @@
+export { DashBoardButton } from "./DashBoardButton"

--- a/components/atoms/Greeting/Greeting.stories.tsx
+++ b/components/atoms/Greeting/Greeting.stories.tsx
@@ -1,0 +1,17 @@
+import { ComponentStory, ComponentMeta } from "@storybook/react"
+import { Greeting } from "./Greeting"
+
+export default {
+  title: "Components/Atoms/Greeting",
+  component: Greeting,
+  argTypes: {
+    userName: {
+      defaultValue: "username",
+      control: "text",
+    },
+  },
+} as ComponentMeta<typeof Greeting>
+
+export const Default: ComponentStory<typeof Greeting> = (args) => {
+  return <Greeting {...args} />
+}

--- a/components/atoms/Greeting/Greeting.styles.ts
+++ b/components/atoms/Greeting/Greeting.styles.ts
@@ -1,0 +1,22 @@
+import styled from "@emotion/styled"
+
+export const Container = styled.div`
+  width: 18rem;
+  max-height: 6rem;
+
+  color: white;
+
+  font-size: 1.5rem;
+  font-weight: 900;
+
+  overflow: hidden;
+  word-break: keep-all;
+`
+
+export const UserName = styled.span`
+  color: #8294ff;
+`
+
+export const GreetingMent = styled.div`
+  width: 100%;
+`

--- a/components/atoms/Greeting/Greeting.tsx
+++ b/components/atoms/Greeting/Greeting.tsx
@@ -1,0 +1,23 @@
+import { useState } from "react"
+import { IGreetingProps } from "types"
+import * as S from "./Greeting.styles"
+
+const greetingMents = [
+  "오늘도 오늘의 스티커를 향해 달려 볼까요? ♪( 'ω' و)و",
+  "지금까지 너무 잘 해 오고 있어요! 오늘도 화이팅 :3",
+  "오늘의 목표는 무엇인가요?? 남은 하루도 화이팅 :)",
+]
+
+export function Greeting({ userName, ...props }: IGreetingProps) {
+  const greetingMent = greetingMents[Math.floor(Math.random() * 3)]
+
+  return (
+    <S.Container style={{ ...props }}>
+      <div>
+        <S.UserName>{userName}</S.UserName>
+        <span>님,</span>
+      </div>
+      <S.GreetingMent>{greetingMent}</S.GreetingMent>
+    </S.Container>
+  )
+}

--- a/types/atom.d.ts
+++ b/types/atom.d.ts
@@ -38,3 +38,7 @@ export interface IDashBoardButtonProps {
   backgroundColor: string
   image?: string
 }
+
+export interface IGreetingProps {
+  userName: string
+}

--- a/types/atom.d.ts
+++ b/types/atom.d.ts
@@ -35,5 +35,6 @@ export interface IDashBoardButtonProps {
   desc: string
   width?: number
   height: number
-  image?: ImageData
+  backgroundColor: string
+  image?: string
 }

--- a/types/atom.d.ts
+++ b/types/atom.d.ts
@@ -17,9 +17,23 @@ export interface IIconProps {
   alt: string
 }
 
-interface ISignButtonProps {
+export interface ISignButtonProps {
   content?: string
   width?: number
   color?: string
   backgroundColor?: string
+}
+
+export interface ICurrentNumberProps {
+  width?: number
+  title?: string
+  count: number
+}
+
+export interface IDashBoardButtonProps {
+  title: string
+  desc: string
+  width?: number
+  height: number
+  image?: ImageData
 }

--- a/types/index.ts
+++ b/types/index.ts
@@ -4,6 +4,7 @@ export type {
   IIconProps,
   ICurrentNumberProps,
   IDashBoardButtonProps,
+  IGreetingProps,
 } from "types/atom"
 
 export type { ISignInputProps } from "types/molecule"

--- a/types/index.ts
+++ b/types/index.ts
@@ -1,4 +1,10 @@
-export type { IBaseCardContainerProps, ILogoProps, IIconProps } from "types/atom"
+export type {
+  IBaseCardContainerProps,
+  ILogoProps,
+  IIconProps,
+  ICurrentNumberProps,
+  IDashBoardButtonProps,
+} from "types/atom"
 
 export type { ISignInputProps } from "types/molecule"
 


### PR DESCRIPTION
## 구현내용

### 대시보드_atom 단위 컴포넌트 및 스토리북 구헌

#### Greeting

용도 및 특징 : 유저의 이름과 인삿말이 표현되는 컴포넌트.
매 새로고침마다 인삿말이 랜덤으로 변경된다. 현재는 3개의 인삿말이 입력되어 있다.

<img width="400" alt="image" src="https://user-images.githubusercontent.com/97934878/195267674-590da07b-a9ce-4c76-b675-b748bb70884e.png">

<br>

#### CurrentNumber

용도 및 특징 : 특정 타이틀과 숫자를 강조하여 나타낼 수 있는 컴포넌트. 주로 현재 진행중인 것과 진행 개수를 나타내는데 사용 될 예정이다. 제목 용도의 title props는 넣어도 되고 넣지 않아도 된다.

<img width="400" alt="image" src="https://user-images.githubusercontent.com/97934878/195268026-7324fca8-2066-45f7-a94a-10c9c60793de.png">

<br>

#### DashBoardButton

용도 및 특징 : 대시보드의 페이지 이동 버튼에서 쓰일 컴포넌트. 넓이, 높이, 색상, 이미지등을 자유자재로 커스텀 할 수 있다.

<img width="499" alt="image" src="https://user-images.githubusercontent.com/97934878/195268320-a4027037-cede-4e89-8cd3-f0cb7fd0b0ae.png">


<br>
<br>



