### PR TITLE
STICKI-12 / 대시보드_molecule 단위 컴포넌트 및 스토리북 구현

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,4 +1,5 @@
 import * as NextImage from "next/image"
+import GlobalStyle from '../styles/GlobalStyle';
 
 const OriginalNextImage = NextImage.default
 
@@ -6,6 +7,15 @@ Object.defineProperty(NextImage, "default", {
   configurable: true,
   value: (props) => <OriginalNextImage {...props} unoptimized />,
 })
+
+export const decorators = [
+  (Story) => (
+    <>
+      <GlobalStyle />
+      <Story />
+    </>
+  ),
+];
 
 export const parameters = {
   actions: { argTypesRegex: "^on[A-Z].*" },

--- a/components/atoms/DashBoardButton/DashBoardButton.styles.ts
+++ b/components/atoms/DashBoardButton/DashBoardButton.styles.ts
@@ -1,8 +1,6 @@
 import styled from "@emotion/styled"
 
 interface IContainerProps {
-  width?: number
-  height: number
   backgroundColor: string
 }
 
@@ -11,8 +9,8 @@ export const Container = styled.div<IContainerProps>`
   flex-direction: column;
   position: relative;
 
-  width: ${({ width }) => (width ? `${width}rem` : "100%")};
-  height: ${({ height }) => `${height}rem`};
+  width: 100%;
+  height: 100%;
   padding: 1rem;
 
   border-radius: 1rem;
@@ -39,8 +37,6 @@ export const Desc = styled.div`
 
   color: white;
   font-size: 0.6rem;
-
-  word-break: keep-all;
 `
 export const ImageContainer = styled.div`
   position: absolute;

--- a/components/atoms/DashBoardButton/DashBoardButton.tsx
+++ b/components/atoms/DashBoardButton/DashBoardButton.tsx
@@ -5,14 +5,12 @@ import * as S from "./DashBoardButton.styles"
 export function DashBoardButton({
   title,
   desc,
-  width,
-  height,
   image,
   backgroundColor,
   ...props
 }: IDashBoardButtonProps) {
   return (
-    <S.Container width={width} height={height} backgroundColor={backgroundColor}>
+    <S.Container backgroundColor={backgroundColor}>
       <S.Title>{title}</S.Title>
       {desc ? <S.Desc>{desc}</S.Desc> : null}
       {image ? (

--- a/components/index.ts
+++ b/components/index.ts
@@ -8,6 +8,7 @@ import { Greeting } from "./atoms/Greeting"
 
 import { SignInput } from "./molecules/SignInput"
 import { BoardStatus } from "./molecules/BoardStatus"
+import { LinkGrid } from "./molecules/LinkGrid"
 
 import { SignForm } from "./organisms/SignForm"
 
@@ -22,4 +23,5 @@ export {
   Greeting,
   DashBoardButton,
   BoardStatus,
+  LinkGrid,
 }

--- a/components/index.ts
+++ b/components/index.ts
@@ -7,6 +7,7 @@ import { DashBoardButton } from "./atoms/DashBoardButton"
 import { Greeting } from "./atoms/Greeting"
 
 import { SignInput } from "./molecules/SignInput"
+import { BoardStatus } from "./molecules/BoardStatus"
 
 import { SignForm } from "./organisms/SignForm"
 
@@ -20,4 +21,5 @@ export {
   CurrentNumber,
   Greeting,
   DashBoardButton,
+  BoardStatus,
 }

--- a/components/molecules/BoardStatus/BoardStatus.stories.tsx
+++ b/components/molecules/BoardStatus/BoardStatus.stories.tsx
@@ -1,0 +1,40 @@
+import { ComponentStory, ComponentMeta } from "@storybook/react"
+import { BoardStatus } from "./BoardStatus"
+
+export default {
+  title: "Components/Molecules/BoardStatus",
+  component: BoardStatus,
+  argTypes: {
+    wholeBoardCount: {
+      defaultValue: 100,
+      control: {
+        type: "range",
+        min: 0,
+        max: 100,
+        step: 10,
+      },
+    },
+    onGoingBoardCount: {
+      defaultValue: 80,
+      control: {
+        type: "range",
+        min: 0,
+        max: 100,
+        step: 10,
+      },
+    },
+    completedBoardCount: {
+      defaultValue: 10,
+      control: {
+        type: "range",
+        min: 0,
+        max: 100,
+        step: 10,
+      },
+    },
+  },
+} as ComponentMeta<typeof BoardStatus>
+
+export const Default: ComponentStory<typeof BoardStatus> = (args) => {
+  return <BoardStatus {...args} />
+}

--- a/components/molecules/BoardStatus/BoardStatus.styles.ts
+++ b/components/molecules/BoardStatus/BoardStatus.styles.ts
@@ -6,6 +6,4 @@ export const Container = styled.div`
 
   width: 100%;
   height: fit-content;
-
-  border: 1px solid;
 `

--- a/components/molecules/BoardStatus/BoardStatus.styles.ts
+++ b/components/molecules/BoardStatus/BoardStatus.styles.ts
@@ -1,0 +1,11 @@
+import styled from "@emotion/styled"
+
+export const Container = styled.div`
+  display: flex;
+  justify-content: space-between;
+
+  width: 100%;
+  height: fit-content;
+
+  border: 1px solid;
+`

--- a/components/molecules/BoardStatus/BoardStatus.tsx
+++ b/components/molecules/BoardStatus/BoardStatus.tsx
@@ -1,0 +1,18 @@
+import { CurrentNumber } from "components"
+import * as S from "./BoardStatus.styles"
+import { IBoardStatusProps } from "types"
+
+export function BoardStatus({
+  wholeBoardCount,
+  onGoingBoardCount,
+  completedBoardCount,
+  ...props
+}: IBoardStatusProps) {
+  return (
+    <S.Container>
+      <CurrentNumber title="전체 스티커보드" count={wholeBoardCount} />
+      <CurrentNumber title="진행중인 스티커보드" count={onGoingBoardCount} />
+      <CurrentNumber title="완료한 스티커보드" count={completedBoardCount} />
+    </S.Container>
+  )
+}

--- a/components/molecules/BoardStatus/index.ts
+++ b/components/molecules/BoardStatus/index.ts
@@ -1,0 +1,1 @@
+export { BoardStatus } from "./BoardStatus"

--- a/components/molecules/LinkGrid/LinkGrid.stories.tsx
+++ b/components/molecules/LinkGrid/LinkGrid.stories.tsx
@@ -1,0 +1,12 @@
+import { ComponentStory, ComponentMeta } from "@storybook/react"
+import { LinkGrid } from "./LinkGrid"
+
+export default {
+  title: "Components/Molecules/LinkGrid",
+  component: LinkGrid,
+  argTypes: {},
+} as ComponentMeta<typeof LinkGrid>
+
+export const Default: ComponentStory<typeof LinkGrid> = (args) => {
+  return <LinkGrid {...args} />
+}

--- a/components/molecules/LinkGrid/LinkGrid.styles.ts
+++ b/components/molecules/LinkGrid/LinkGrid.styles.ts
@@ -1,0 +1,39 @@
+import styled from "@emotion/styled"
+
+export const Container = styled.div`
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  grid-template-rows: 10.5rem 5.5rem auto;
+  gap: 1rem;
+
+  width: 22.5rem;
+  height: 24.5rem;
+
+  > div:nth-of-type(1) {
+    grid-row-start: 1;
+    grid-row-end: 3;
+    grid-column-start: 1;
+    grid-column-end: 2;
+  }
+
+  > div:nth-of-type(2) {
+    grid-row-start: 1;
+    grid-row-end: 2;
+    grid-column-start: 2;
+    grid-column-end: 3;
+  }
+
+  > div:nth-of-type(3) {
+    grid-row-start: 3;
+    grid-row-end: 4;
+    grid-column-start: 1;
+    grid-column-end: 2;
+  }
+
+  > div:nth-of-type(4) {
+    grid-row-start: 2;
+    grid-row-end: 4;
+    grid-column-start: 2;
+    grid-column-end: 3;
+  }
+`

--- a/components/molecules/LinkGrid/LinkGrid.tsx
+++ b/components/molecules/LinkGrid/LinkGrid.tsx
@@ -1,0 +1,53 @@
+import Link from "next/link"
+import { DashBoardButton } from "components"
+import * as S from "./LinkGrid.styles"
+
+export function LinkGrid({ ...props }) {
+  return (
+    <S.Container>
+      <div>
+        <Link href="#">
+          <DashBoardButton
+            title="OnGoing
+STICKIES”"
+            desc="현재 진행중인 스티키보드를 
+          확인하세요"
+            backgroundColor="linear-gradient(168.88deg, #C8D0FF 4.71%, #9CABFF 95.63%)"
+          />
+        </Link>
+      </div>
+      <div>
+        <Link href="#">
+          <DashBoardButton
+            title="STICKI”
+History"
+            desc="그동안의 스티키보드 기록들을
+          확인 해 볼 수 있어요"
+            backgroundColor="linear-gradient(133.61deg, #FFE7DD 2.18%, #FFC7AF 98.43%)"
+          />
+        </Link>
+      </div>
+      <div>
+        <Link href="#">
+          <DashBoardButton
+            title="Sticki
+Collections"
+            desc="지금까지 모은 스티키보드와
+          칭찬스티커를 확인할 수 있어요"
+            backgroundColor="linear-gradient(132.14deg, #F2D7FF 12.28%, #E2A6FF 87.41%)"
+          />
+        </Link>
+      </div>
+      <div>
+        <Link href="#">
+          <DashBoardButton
+            title="Community"
+            desc="친구들과 챌린지를 공유하고
+응원을 보낼 수 있어요"
+            backgroundColor="linear-gradient(162.18deg, #DBD6FF 6.54%, #B7ACFF 93.46%)"
+          />
+        </Link>
+      </div>
+    </S.Container>
+  )
+}

--- a/components/molecules/LinkGrid/index.ts
+++ b/components/molecules/LinkGrid/index.ts
@@ -1,0 +1,1 @@
+export { LinkGrid } from "./LinkGrid"

--- a/styles/GlobalStyle.tsx
+++ b/styles/GlobalStyle.tsx
@@ -1,0 +1,142 @@
+import { Global, css } from "@emotion/react"
+
+const GlobalStyle = () => (
+  <Global
+    styles={css`
+      @import url(//fonts.googleapis.com/earlyaccess/notosanskr.css);
+      html,
+      body,
+      div,
+      span,
+      applet,
+      object,
+      iframe,
+      h1,
+      h2,
+      h3,
+      h4,
+      h5,
+      h6,
+      p,
+      blockquote,
+      pre,
+      a,
+      abbr,
+      acronym,
+      address,
+      big,
+      cite,
+      code,
+      del,
+      dfn,
+      em,
+      img,
+      ins,
+      kbd,
+      q,
+      s,
+      samp,
+      small,
+      strike,
+      strong,
+      sub,
+      sup,
+      tt,
+      var,
+      b,
+      u,
+      i,
+      center,
+      dl,
+      dt,
+      dd,
+      ol,
+      ul,
+      li,
+      fieldset,
+      form,
+      label,
+      legend,
+      table,
+      caption,
+      tbody,
+      tfoot,
+      thead,
+      tr,
+      th,
+      td,
+      article,
+      aside,
+      canvas,
+      details,
+      embed,
+      figure,
+      figcaption,
+      footer,
+      header,
+      hgroup,
+      menu,
+      nav,
+      output,
+      ruby,
+      section,
+      summary,
+      time,
+      mark,
+      audio,
+      input,
+      textarea,
+      video {
+        margin: 0;
+        padding: 0;
+        border: 0;
+        font-size: 100%;
+        font: inherit;
+        vertical-align: baseline;
+        box-sizing: border-box;
+      }
+      html {
+        font-size: 62.5%;
+        font-family: "Noto Sans KR", "sans-serif";
+        body {
+          font-size: 1.6rem;
+        }
+      }
+      ol,
+      ul {
+        list-style: none;
+      }
+      a {
+        background-color: transparent;
+        text-decoration: none;
+        outline: none;
+        color: inherit;
+        &:active,
+        &:hover {
+          text-decoration: none;
+          color: inherit;
+          outline: 0;
+        }
+      }
+      button {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        outline: none;
+        border: none;
+        background: none;
+        padding: 0;
+        user-select: none;
+        cursor: pointer;
+        white-space: nowrap;
+        letter-spacing: inherit;
+        font: inherit;
+        color: inherit;
+      }
+      input {
+        outline: none;
+      }
+    `}
+  />
+)
+export default GlobalStyle

--- a/types/atom.d.ts
+++ b/types/atom.d.ts
@@ -33,8 +33,6 @@ export interface ICurrentNumberProps {
 export interface IDashBoardButtonProps {
   title: string
   desc: string
-  width?: number
-  height: number
   backgroundColor: string
   image?: string
 }

--- a/types/index.ts
+++ b/types/index.ts
@@ -7,6 +7,6 @@ export type {
   IGreetingProps,
 } from "types/atom"
 
-export type { ISignInputProps } from "types/molecule"
+export type { ISignInputProps, IBoardStatusProps } from "types/molecule"
 
 export type { ISignFormProps } from "types/organism"

--- a/types/molecule.d.ts
+++ b/types/molecule.d.ts
@@ -3,3 +3,9 @@ export interface ISignInputProps {
   alertContent: string
   isAlertVisible: boolean
 }
+
+export interface IBoardStatusProps {
+  wholeBoardCount: number
+  onGoingBoardCount: number
+  completedBoardCount: number
+}


### PR DESCRIPTION
## 구현

### 대시보드_molecule 단위 컴포넌트 및 스토리북 구현

#### BoardStatus

용도 및 특징 : 현재 진행중인 보드의 카운트를 표현하는 컴포넌트

<img width="400" alt="image" src="https://user-images.githubusercontent.com/97934878/195284442-3d2ad56b-bb5f-40af-a465-10626ef7f3c4.png">


<br>

#### LinkGrid

용도 및 특징 : 대시보드에서 각 페이지로 이동하기 위한 버튼 컴포넌트

<img width="400" alt="image" src="https://user-images.githubusercontent.com/97934878/195284635-e7fd75e1-500c-4abc-bbbf-6275b00d558f.png">

<br>
<br>