### PR TITLE
STICKI-17 / 목표 페이지 molecule 단위 컴포넌트 구현

### DIFF
--- a/components/atoms/BaseContainer/BaseContainer.styles.ts
+++ b/components/atoms/BaseContainer/BaseContainer.styles.ts
@@ -7,8 +7,8 @@ export const Container = styled.div<IBaseCardContainerProps>`
   align-items: center;
   gap: 1rem;
 
-  width: ${({ width }) => (width ? `${width}rem` : "fit-content")};
-  height: ${({ height }) => (height ? `${height}rem` : "fit-content")};
+  width: ${({ width }) => (width ? width : "100%")};
+  height: ${({ height }) => (height ? height : "fit-content")};
   padding: ${({ padding }) => (padding ? padding : "2rem 1rem")};
   border-radius: ${({ borderRadius }) => (borderRadius ? `${borderRadius}rem` : "2rem")};
   background-color: ${({ backgroundColor }) => (backgroundColor ? backgroundColor : "white")};

--- a/components/index.ts
+++ b/components/index.ts
@@ -1,3 +1,4 @@
+// atom 단위 컴포넌트들
 import { BaseContainer } from "./atoms/BaseContainer"
 import { Icon } from "./atoms/Icon"
 import { Logo } from "./atoms/Logo"
@@ -8,10 +9,13 @@ import { Greeting } from "./atoms/Greeting"
 import { PageTitle } from "./atoms/PageTitle"
 import { CreateBoardButton } from "./atoms/CreateBoardButton"
 
+// molecule 단위 컴포넌트들
 import { SignInput } from "./molecules/SignInput"
 import { BoardStatus } from "./molecules/BoardStatus"
 import { LinkGrid } from "./molecules/LinkGrid"
+import { BoardPreviewCard } from "./molecules/BoardPreviewCard"
 
+// organism 단위 컴포넌트들
 import { SignForm } from "./organisms/SignForm"
 import { DashBoardStatus } from "./organisms/DashBoardStatus"
 import { DashBoardMain } from "./organisms/DashBoardMain"
@@ -32,4 +36,5 @@ export {
   DashBoardMain,
   PageTitle,
   CreateBoardButton,
+  BoardPreviewCard,
 }

--- a/components/molecules/BoardPreviewCard/BoardPreviewCard.stories.tsx
+++ b/components/molecules/BoardPreviewCard/BoardPreviewCard.stories.tsx
@@ -1,0 +1,42 @@
+import { ComponentStory, ComponentMeta } from "@storybook/react"
+import { BoardPreviewCard } from "./BoardPreviewCard"
+
+export default {
+  title: "Components/Molecules/BoardPreviewCard",
+  component: BoardPreviewCard,
+  argTypes: {
+    imageLink: {
+      defaultValue: "https://i1.sndcdn.com/artworks-CDyMPstbky5qw7oe-NfF8Pg-t240x240.jpg",
+    },
+    title: {
+      defaultValue: "매일 매일 꾸준히 물 마시기",
+      control: "text",
+    },
+    date: {
+      defaultValue: "2022.04.18 ~ 2022.05.13",
+      control: "text",
+    },
+    wholeCount: {
+      defaultValue: 12,
+      control: {
+        type: "range",
+        min: 5,
+        max: 30,
+        step: 5,
+      },
+    },
+    currentCount: {
+      defaultValue: 5,
+      control: {
+        type: "range",
+        min: 0,
+        max: 25,
+        step: 5,
+      },
+    },
+  },
+} as ComponentMeta<typeof BoardPreviewCard>
+
+export const Default: ComponentStory<typeof BoardPreviewCard> = (args) => {
+  return <BoardPreviewCard {...args} />
+}

--- a/components/molecules/BoardPreviewCard/BoardPreviewCard.styles.ts
+++ b/components/molecules/BoardPreviewCard/BoardPreviewCard.styles.ts
@@ -1,0 +1,55 @@
+import styled from "@emotion/styled"
+
+export const Container = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+
+  gap: 1rem;
+
+  width: 100%;
+  height: 10vh;
+  min-height: 6rem;
+`
+
+export const ImageContainer = styled.div`
+  flex-shrink: 0;
+  position: relative;
+
+  width: 10vh;
+  min-width: 6rem;
+  height: 100%;
+`
+
+export const MidContainer = styled.div`
+  flex-grow: 1;
+
+  width: 1rem;
+  flex-grow: 1;
+`
+
+export const Title = styled.div`
+  width: 100%;
+
+  font-size: 1.4rem;
+  font-weight: 700;
+  word-break: keep-all;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+`
+
+export const Date = styled.div`
+  color: lightgray;
+
+  font-size: 1.3rem;
+  font-weight: 300;
+`
+
+export const Status = styled.div`
+  flex-shrink: 0;
+
+  color: #b5c0ff;
+
+  font-weight: 900;
+`

--- a/components/molecules/BoardPreviewCard/BoardPreviewCard.tsx
+++ b/components/molecules/BoardPreviewCard/BoardPreviewCard.tsx
@@ -1,0 +1,34 @@
+import Image from "next/image"
+import { BaseContainer } from "components"
+import * as S from "./BoardPreviewCard.styles"
+import { IBoardPreviewCardProps } from "types"
+
+export function BoardPreviewCard({
+  imageLink,
+  title,
+  date,
+  wholeCount,
+  currentCount,
+  ...props
+}: IBoardPreviewCardProps) {
+  return (
+    <BaseContainer padding="1rem">
+      <S.Container>
+        <S.ImageContainer>
+          <Image
+            src={imageLink}
+            layout="fill"
+            objectFit="cover"
+            style={{ borderRadius: 8 }}
+            alt={`${title} image`}
+          />
+        </S.ImageContainer>
+        <S.MidContainer>
+          <S.Title>{title}</S.Title>
+          <S.Date>{date}</S.Date>
+        </S.MidContainer>
+        <S.Status>{`${currentCount} / ${wholeCount}`}</S.Status>
+      </S.Container>
+    </BaseContainer>
+  )
+}

--- a/components/molecules/BoardPreviewCard/index.ts
+++ b/components/molecules/BoardPreviewCard/index.ts
@@ -1,0 +1,1 @@
+export { BoardPreviewCard } from "./BoardPreviewCard"

--- a/types/atom.d.ts
+++ b/types/atom.d.ts
@@ -1,10 +1,10 @@
 export interface IBaseCardContainerProps {
-  width?: number
-  height?: number
+  width?: number | string
+  height?: number | string
   padding?: string
   borderRadius?: number
   backgroundColor?: string
-  children: JSX.Element[]
+  children: JSX.Element[] | JSX.Element
 }
 
 export interface ILogoProps {

--- a/types/index.ts
+++ b/types/index.ts
@@ -8,6 +8,6 @@ export type {
   IPageTitleProps,
 } from "types/atom"
 
-export type { ISignInputProps, IBoardStatusProps } from "types/molecule"
+export type { ISignInputProps, IBoardStatusProps, IBoardPreviewCardProps } from "types/molecule"
 
 export type { ISignFormProps, IDashBoardStatusProps } from "types/organism"

--- a/types/molecule.d.ts
+++ b/types/molecule.d.ts
@@ -9,3 +9,11 @@ export interface IBoardStatusProps {
   onGoingBoardCount: number
   completedBoardCount: number
 }
+
+export interface IBoardPreviewCardProps {
+  imageLink: string
+  title: string
+  date: string
+  wholeCount: number
+  currentCount: number
+}


### PR DESCRIPTION
## 설명

### 목표 페이지 molecule 단위 컴포넌트 구현

#### BoardPreviewCard

용도 및 목적 : 목표 페이지에서 스티키보드 리스트의 썸네일로 쓰일 카드 컴포넌트. 반응형으로 제작하였다.

<img width="523" alt="image" src="https://user-images.githubusercontent.com/97934878/195485511-09777aef-44ed-42f7-ad9c-995d4c1c52cd.png">

<br>
<br>

### 참고

#### viewport별 font-size 조정

viewport 크기별로 font-size를 조정하는 방법은 media밖에 없는 걸까

<br>
<br>
