### PR TITLE
STICKI-19 / OnGoingTemplate 컴포넌트 및 스토리북 구현

### DIFF
--- a/components/organisms/BottomNavBar/BottomNavBar.styles.ts
+++ b/components/organisms/BottomNavBar/BottomNavBar.styles.ts
@@ -9,9 +9,10 @@ export const Container = styled.nav`
   bottom: 0;
 
   width: 100%;
-  height: 5vh;
-  min-height: 5rem;
+  height: 5rem;
   padding: 1rem;
+
+  background-color: white;
 
   border-top: 1px solid #b5c0ff;
 

--- a/components/template/OnGoingTemplate.stories.tsx
+++ b/components/template/OnGoingTemplate.stories.tsx
@@ -1,0 +1,89 @@
+import { ComponentStory, ComponentMeta } from "@storybook/react"
+import { OnGoingTemplate } from "./OnGoingTemplate"
+
+const dummyData = [
+  {
+    title: "제목1",
+    date: "2022.02.13",
+    wholeCount: 10,
+    currentCount: 3,
+    imageLink: "https://i1.sndcdn.com/artworks-CDyMPstbky5qw7oe-NfF8Pg-t240x240.jpg",
+  },
+  {
+    title: "제목2",
+    date: "2022.02.13",
+    wholeCount: 10,
+    currentCount: 3,
+    imageLink: "https://i1.sndcdn.com/artworks-CDyMPstbky5qw7oe-NfF8Pg-t240x240.jpg",
+  },
+  {
+    title: "제목3",
+    date: "2022.02.13",
+    wholeCount: 10,
+    currentCount: 3,
+    imageLink: "https://i1.sndcdn.com/artworks-CDyMPstbky5qw7oe-NfF8Pg-t240x240.jpg",
+  },
+  {
+    title: "제목4",
+    date: "2022.02.13",
+    wholeCount: 10,
+    currentCount: 3,
+    imageLink: "https://i1.sndcdn.com/artworks-CDyMPstbky5qw7oe-NfF8Pg-t240x240.jpg",
+  },
+  {
+    title: "제목5",
+    date: "2022.02.13",
+    wholeCount: 10,
+    currentCount: 3,
+    imageLink: "https://i1.sndcdn.com/artworks-CDyMPstbky5qw7oe-NfF8Pg-t240x240.jpg",
+  },
+  {
+    title: "제목6",
+    date: "2022.02.13",
+    wholeCount: 10,
+    currentCount: 3,
+    imageLink: "https://i1.sndcdn.com/artworks-CDyMPstbky5qw7oe-NfF8Pg-t240x240.jpg",
+  },
+  {
+    title: "제목7",
+    date: "2022.02.13",
+    wholeCount: 10,
+    currentCount: 3,
+    imageLink: "https://i1.sndcdn.com/artworks-CDyMPstbky5qw7oe-NfF8Pg-t240x240.jpg",
+  },
+  {
+    title: "제목8",
+    date: "2022.02.13",
+    wholeCount: 10,
+    currentCount: 3,
+    imageLink: "https://i1.sndcdn.com/artworks-CDyMPstbky5qw7oe-NfF8Pg-t240x240.jpg",
+  },
+  {
+    title: "제목9",
+    date: "2022.02.13",
+    wholeCount: 10,
+    currentCount: 3,
+    imageLink: "https://i1.sndcdn.com/artworks-CDyMPstbky5qw7oe-NfF8Pg-t240x240.jpg",
+  },
+  {
+    title: "제목10",
+    date: "2022.02.13",
+    wholeCount: 10,
+    currentCount: 3,
+    imageLink: "https://i1.sndcdn.com/artworks-CDyMPstbky5qw7oe-NfF8Pg-t240x240.jpg",
+  },
+]
+
+export default {
+  title: "Components/Templates/OnGoingTemplate",
+  component: OnGoingTemplate,
+  argTypes: {
+    boardListData: {
+      defaultValue: dummyData,
+    },
+  },
+} as ComponentMeta<typeof OnGoingTemplate>
+
+export const Default: ComponentStory<typeof OnGoingTemplate> = (args) => {
+  return <OnGoingTemplate {...args} />
+}

--- a/components/template/OnGoingTemplate.styles.ts
+++ b/components/template/OnGoingTemplate.styles.ts
@@ -1,0 +1,16 @@
+import styled from "@emotion/styled"
+
+export const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+
+  position: fixed;
+  left: 0;
+  top: 0;
+
+  padding: 5rem 1rem 6rem 1rem;
+
+  width: 100vw;
+  height: 100vh;
+`

--- a/components/template/OnGoingTemplate.tsx
+++ b/components/template/OnGoingTemplate.tsx
@@ -1,0 +1,13 @@
+import { PageTitle, OnGoingBoardList, BottomNavBar } from "components"
+import * as S from "./OnGoingTemplate.styles"
+import { IOnGoingBoardListProps } from "types"
+
+export function OnGoingTemplate({ boardListData, ...props }: IOnGoingBoardListProps) {
+  return (
+    <S.Container style={{ ...props }}>
+      <PageTitle title='OnGoing Stickies"' desc="현재 진행중인 스티키보드를 확인하세요" />
+      <OnGoingBoardList boardListData={boardListData} />
+      <BottomNavBar />
+    </S.Container>
+  )
+}

--- a/components/template/index.ts
+++ b/components/template/index.ts
@@ -1,0 +1,1 @@
+export { OnGoingTemplate } from "./OnGoingTemplate"

--- a/types/organism.d.ts
+++ b/types/organism.d.ts
@@ -12,5 +12,5 @@ export interface IDashBoardStatusProps {
 }
 
 export interface IOnGoingBoardListProps {
-  boardListData: IBoardPreviewCardProps[]
+  boardListData: IBoardPreviewCardProps[] | []
 }


### PR DESCRIPTION
## 구현 내용

### OnGoingTemplate 컴포넌트 및 스토리북 구현

#### OnGoingTemplate

용도 : OnGoingPage에서의 template

<img width="634" alt="image" src="https://user-images.githubusercontent.com/97934878/195495939-ee146c3d-a845-4fbd-994f-2f26e8b94674.png">
